### PR TITLE
Fix error that application can not startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
                 <dependency>
                     <groupId>com.azure.spring</groupId>
                     <artifactId>azure-spring-boot-starter-keyvault-certificates</artifactId>
-                    <version>3.0.0-beta.3</version> <!-- {x-version-update;com.azure.spring:azure-spring-boot-starter-keyvault-certificates;current} -->
+                    <version>3.0.0-beta.4</version> <!-- {x-version-update;com.azure.spring:azure-spring-boot-starter-keyvault-certificates;current} -->
                 </dependency>
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,12 @@ azure.activedirectory.client-secret=
 azure.activedirectory.user-group.allowed-groups=group1
 
 azure.keyvault.uri=https://mykeyvault1.vault.azure.net/
-
+# Specifies your Active Directory ID:
+azure.keyvault.tenant-id=
+# Specifies your App Registration's Application ID:
+azure.keyvault.client-id=
+# Specifies your App Registration's secret key:
+azure.keyvault.client-secret=
 
 server.ssl.key-alias=mycertname
 server.ssl.key-store-type=AzureKeyVault


### PR DESCRIPTION
 - Upgrade azure-spring-boot-starter-keyvault-certificates's version to 3.0.0-beta.4.
 - Add necessary keyvault properties.

Now the `keyvault` and `active directory` do not share properties like `tenant-id, client-id, client-secret`. 
I have a plan to uniform these properties.